### PR TITLE
fixed duplicate methods and BindRenderbuffer

### DIFF
--- a/gl_empty.go
+++ b/gl_empty.go
@@ -199,6 +199,7 @@ type Context struct {
 	RGB565                                       int
 	RGBA                                         int
 	RGBA4                                        int
+	RGBA8                                        int
 	SAMPLER_2D                                   int
 	SAMPLER_CUBE                                 int
 	SAMPLES                                      int

--- a/gl_empty.go
+++ b/gl_empty.go
@@ -487,7 +487,7 @@ func (c *Context) DeleteRenderBuffer(rb *RenderBuffer) {
 func (c *Context) BindRenderBuffer(rb *RenderBuffer) {
 }
 
-func (c *Context) RenderBufferStorage(internalFormat uint32, width, height int) {
+func (c *Context) RenderBufferStorage(internalFormat int, width, height int) {
 }
 
 func (c *Context) CreateFrameBuffer() *FrameBuffer {
@@ -500,8 +500,8 @@ func (c *Context) DeleteFrameBuffer(fb *FrameBuffer) {
 func (c *Context) BindFrameBuffer(fb *FrameBuffer) {
 }
 
-func (c *Context) FrameBufferTexture2D(target, attachment, texTarget uint32, t *Texture, level int) {
+func (c *Context) FrameBufferTexture2D(target, attachment, texTarget int, t *Texture, level int) {
 }
 
-func (c *Context) FrameBufferRenderBuffer(target, attachment uint32, rb *RenderBuffer) {
+func (c *Context) FrameBufferRenderBuffer(target, attachment int, rb *RenderBuffer) {
 }

--- a/gl_empty.go
+++ b/gl_empty.go
@@ -395,6 +395,8 @@ func (c *Context) TexParameteri(target int, pname int, param int) {}
 
 func (c *Context) TexImage2D(target, level, internalFormat, format, kind int, data interface{}) {}
 
+func (c *Context) TexImage2DEmpty(target, level, internalFormat, format, kind, width, height int) {}
+
 func (c *Context) GetAttribLocation(program *Program, name string) int {
 	return 0
 }

--- a/gl_gl2.go
+++ b/gl_gl2.go
@@ -782,6 +782,10 @@ func (c *Context) TexImage2D(target, level, internalFormat, format, kind int, da
 	gl.TexImage2D(uint32(target), int32(level), int32(internalFormat), int32(width), int32(height), int32(0), uint32(format), uint32(kind), gl.Ptr(pix))
 }
 
+func (c *Context) TexImage2DEmpty(target, level, internalFormat, format, kind, width, height int) {
+	gl.TexImage2D(uint32(target), int32(level), int32(internalFormat), int32(width), int32(height), int32(0), uint32(format), uint32(kind), nil)
+}
+
 func (c *Context) GetAttribLocation(program *Program, name string) int {
 	return int(gl.GetAttribLocation(program.uint32, gl.Str(name+"\x00")))
 }

--- a/gl_gl2.go
+++ b/gl_gl2.go
@@ -971,7 +971,11 @@ func (c *Context) DeleteRenderBuffer(rb *RenderBuffer) {
 
 // BindRenderBuffer binds a named renderbuffer object.
 func (c *Context) BindRenderBuffer(rb *RenderBuffer) {
-	gl.BindRenderbuffer(gl.RENDERBUFFER, rb.uint32)
+	if rb != nil {
+		gl.BindRenderbuffer(gl.RENDERBUFFER, rb.uint32)
+	} else {
+		gl.BindRenderbuffer(gl.RENDERBUFFER, 0)
+	}
 }
 
 // RenderBufferStorage establishes the data storage, format, and dimensions of a renderbuffer object's image.

--- a/gl_gl2.go
+++ b/gl_gl2.go
@@ -981,8 +981,8 @@ func (c *Context) BindRenderBuffer(rb *RenderBuffer) {
 }
 
 // RenderBufferStorage establishes the data storage, format, and dimensions of a renderbuffer object's image.
-func (c *Context) RenderBufferStorage(internalFormat uint32, width, height int) {
-	gl.RenderbufferStorage(gl.RENDERBUFFER, internalFormat, int32(width), int32(height))
+func (c *Context) RenderBufferStorage(internalFormat int, width, height int) {
+	gl.RenderbufferStorage(gl.RENDERBUFFER, uint32(internalFormat), int32(width), int32(height))
 }
 
 // CreateFrameBuffer creates a FrameBuffer object.
@@ -1007,11 +1007,11 @@ func (c *Context) BindFrameBuffer(fb *FrameBuffer) {
 }
 
 // FrameBufferTexture2D attaches a texture to a FrameBuffer
-func (c *Context) FrameBufferTexture2D(target, attachment, texTarget uint32, t *Texture, level int) {
-	gl.FramebufferTexture2D(target, attachment, texTarget, t.uint32, int32(level))
+func (c *Context) FrameBufferTexture2D(target, attachment, texTarget int, t *Texture, level int) {
+	gl.FramebufferTexture2D(uint32(target), uint32(attachment), uint32(texTarget), t.uint32, int32(level))
 }
 
 // FrameBufferRenderBuffer attaches a RenderBuffer object to a FrameBuffer object.
-func (c *Context) FrameBufferRenderBuffer(target, attachment uint32, rb *RenderBuffer) {
-	gl.FramebufferRenderbuffer(target, attachment, gl.RENDERBUFFER, rb.uint32)
+func (c *Context) FrameBufferRenderBuffer(target, attachment int, rb *RenderBuffer) {
+	gl.FramebufferRenderbuffer(uint32(target), uint32(attachment), gl.RENDERBUFFER, rb.uint32)
 }

--- a/gl_gl2.go
+++ b/gl_gl2.go
@@ -204,6 +204,7 @@ type Context struct {
 	RGB565                                       int
 	RGBA                                         int
 	RGBA4                                        int
+	RGBA8                                        int
 	SAMPLER_2D                                   int
 	SAMPLER_CUBE                                 int
 	SAMPLES                                      int
@@ -502,6 +503,7 @@ func NewContext() *Context {
 		RGB565:                                       gl.RGB565,
 		RGBA:                                         gl.RGBA,
 		RGBA4:                                        gl.RGBA4,
+		RGBA8:                                        gl.RGBA8,
 		SAMPLER_2D:                                   gl.SAMPLER_2D,
 		SAMPLER_CUBE:                                 gl.SAMPLER_CUBE,
 		SAMPLES:                                      gl.SAMPLES,

--- a/gl_mobile.go
+++ b/gl_mobile.go
@@ -1331,7 +1331,7 @@ func (c *Context) BindRenderBuffer(rb *RenderBuffer) {
 }
 
 // RenderBufferStorage establishes the data storage, format, and dimensions of a renderbuffer object's image.
-func (c *Context) RenderBufferStorage(internalFormat uint32, width, height int) {
+func (c *Context) RenderBufferStorage(internalFormat int, width, height int) {
 	c.ctx.RenderbufferStorage(gl.RENDERBUFFER, gl.Enum(internalFormat), width, height)
 }
 
@@ -1355,11 +1355,11 @@ func (c *Context) BindFrameBuffer(fb *FrameBuffer) {
 }
 
 // FrameBufferTexture2D attaches a texture to a FrameBuffer
-func (c *Context) FrameBufferTexture2D(target, attachment, texTarget uint32, t *Texture, level int) {
+func (c *Context) FrameBufferTexture2D(target, attachment, texTarget int, t *Texture, level int) {
 	c.ctx.FramebufferTexture2D(gl.Enum(target), gl.Enum(attachment), gl.Enum(texTarget), t.Texture, level)
 }
 
 // FrameBufferRenderBuffer attaches a RenderBuffer object to a FrameBuffer object.
-func (c *Context) FrameBufferRenderBuffer(target, attachment uint32, rb *RenderBuffer) {
+func (c *Context) FrameBufferRenderBuffer(target, attachment int, rb *RenderBuffer) {
 	c.ctx.FramebufferRenderbuffer(gl.Enum(target), gl.Enum(attachment), gl.Enum(c.RENDERBUFFER), rb.Renderbuffer)
 }

--- a/gl_mobile.go
+++ b/gl_mobile.go
@@ -689,24 +689,6 @@ func (c *Context) BindBuffer(target int, buffer *Buffer) {
 	c.ctx.BindBuffer(gl.Enum(target), buffer.Buffer)
 }
 
-// Associates a WebGLFramebuffer object with the FRAMEBUFFER bind target.
-func (c *Context) BindFramebuffer(target int, framebuffer *FrameBuffer) {
-	if framebuffer == nil {
-		c.ctx.BindFramebuffer(gl.Enum(target), gl.Framebuffer{0})
-		return
-	}
-	c.ctx.BindFramebuffer(gl.Enum(target), framebuffer.Framebuffer)
-}
-
-// Binds a WebGLRenderbuffer object to be used for rendering.
-func (c *Context) BindRenderbuffer(target int, renderbuffer *RenderBuffer) {
-	if renderbuffer == nil {
-		c.ctx.BindRenderbuffer(gl.Enum(target), gl.Renderbuffer{0})
-		return
-	}
-	c.ctx.BindRenderbuffer(gl.Enum(target), renderbuffer.Renderbuffer)
-}
-
 // Binds a named texture object to a target.
 func (c *Context) BindTexture(target int, texture *Texture) {
 	if texture == nil {
@@ -1339,7 +1321,11 @@ func (c *Context) DeleteRenderBuffer(rb *RenderBuffer) {
 
 // BindRenderBuffer binds a named renderbuffer object.
 func (c *Context) BindRenderBuffer(rb *RenderBuffer) {
-	c.ctx.BindRenderbuffer(gl.RENDERBUFFER, rb.Renderbuffer)
+	if rb != nil {
+		c.ctx.BindRenderbuffer(gl.RENDERBUFFER, rb.Renderbuffer)
+	} else {
+		c.ctx.BindRenderbuffer(gl.RENDERBUFFER, gl.Renderbuffer{0})
+	}
 }
 
 // RenderBufferStorage establishes the data storage, format, and dimensions of a renderbuffer object's image.

--- a/gl_mobile.go
+++ b/gl_mobile.go
@@ -203,6 +203,7 @@ type Context struct {
 	RGB565                                       int
 	RGBA                                         int
 	RGBA4                                        int
+	RGBA8                                        int
 	SAMPLER_2D                                   int
 	SAMPLER_CUBE                                 int
 	SAMPLES                                      int
@@ -494,6 +495,7 @@ func NewContext(DrawContext interface{}) *Context {
 		RGB565:                                       gl.RGB565,
 		RGBA:                                         gl.RGBA,
 		RGBA4:                                        gl.RGBA4,
+		RGBA8:                                        gl.RGBA8,
 		SAMPLER_2D:                                   gl.SAMPLER_2D,
 		SAMPLER_CUBE:                                 gl.SAMPLER_CUBE,
 		SAMPLES:                                      gl.SAMPLES,

--- a/gl_mobile.go
+++ b/gl_mobile.go
@@ -1198,6 +1198,10 @@ func (c *Context) TexImage2D(target, level, internalFormat, format, kind int, da
 	}
 }
 
+func (c *Context) TexImage2DEmpty(target, level, internalFormat, format, kind, width, height int) {
+	c.ctx.TexImage2D(gl.Enum(target), level, gl.Enum(internalFormat), width, height, gl.Enum(format), gl.Enum(kind), nil)
+}
+
 // Sets texture parameters for the current texture unit.
 func (c *Context) TexParameteri(target int, pname int, param int) {
 	c.ctx.TexParameteri(gl.Enum(target), gl.Enum(pname), param)

--- a/gl_webgl.go
+++ b/gl_webgl.go
@@ -774,24 +774,6 @@ func (c *Context) BindBuffer(target int, buffer *Buffer) {
 	c.Call("bindBuffer", target, buffer.Value)
 }
 
-// Associates a WebGLFramebuffer object with the FRAMEBUFFER bind target.
-func (c *Context) BindFramebuffer(target int, framebuffer *FrameBuffer) {
-	if framebuffer == nil {
-		c.Call("bindFramebuffer", target, nil)
-		return
-	}
-	c.Call("bindFramebuffer", target, framebuffer.Value)
-}
-
-// Binds a WebGLRenderbuffer object to be used for rendering.
-func (c *Context) BindRenderbuffer(target int, renderbuffer *RenderBuffer) {
-	if renderbuffer == nil {
-		c.Call("bindRenderBuffer", target, nil)
-		return
-	}
-	c.Call("bindRenderbuffer", target, renderbuffer)
-}
-
 // Binds a named texture object to a target.
 func (c *Context) BindTexture(target int, texture *Texture) {
 	if texture == nil {
@@ -1442,7 +1424,11 @@ func (c *Context) DeleteRenderBuffer(rb *RenderBuffer) {
 
 // BindRenderBuffer binds a named renderbuffer object.
 func (c *Context) BindRenderBuffer(rb *RenderBuffer) {
-	c.Call("bindRenderbuffer", c.RENDERBUFFER, rb.Value)
+	if rb != nil {
+		c.Call("bindRenderbuffer", c.RENDERBUFFER, rb.Value)
+	} else {
+		c.Call("bindRenderbuffer", c.RENDERBUFFER, nil)
+	}
 }
 
 // RenderBufferStorage establishes the data storage, format, and dimensions of a renderbuffer object's image.
@@ -1465,7 +1451,7 @@ func (c *Context) BindFrameBuffer(fb *FrameBuffer) {
 	if fb != nil {
 		c.Call("bindFramebuffer", c.FRAMEBUFFER, fb.Value)
 	} else {
-		c.Call("bindFramebuffer", c.FRAMEBUFFER, 0)
+		c.Call("bindFramebuffer", c.FRAMEBUFFER, nil)
 	}
 }
 

--- a/gl_webgl.go
+++ b/gl_webgl.go
@@ -235,6 +235,7 @@ type Context struct {
 	RGB565                                       int
 	RGBA                                         int
 	RGBA4                                        int
+	RGBA8                                        int
 	SAMPLER_2D                                   int
 	SAMPLER_CUBE                                 int
 	SAMPLES                                      int
@@ -567,6 +568,7 @@ func (c *Context) InitialContextValues() {
 	c.RGB565 = webCtx.Get("RGB565").Int()
 	c.RGBA = webCtx.Get("RGBA").Int()
 	c.RGBA4 = webCtx.Get("RGBA4").Int()
+	c.RGBA8 = webCtx.Get("RGBA8").Int()
 	c.SAMPLER_2D = webCtx.Get("SAMPLER_2D").Int()
 	c.SAMPLER_CUBE = webCtx.Get("SAMPLER_CUBE").Int()
 	c.SAMPLES = webCtx.Get("SAMPLES").Int()

--- a/gl_webgl.go
+++ b/gl_webgl.go
@@ -1434,7 +1434,7 @@ func (c *Context) BindRenderBuffer(rb *RenderBuffer) {
 }
 
 // RenderBufferStorage establishes the data storage, format, and dimensions of a renderbuffer object's image.
-func (c *Context) RenderBufferStorage(internalFormat uint32, width, height int) {
+func (c *Context) RenderBufferStorage(internalFormat int, width, height int) {
 	c.Call("renderbufferStorage", c.RENDERBUFFER, internalFormat, width, height)
 }
 
@@ -1458,11 +1458,11 @@ func (c *Context) BindFrameBuffer(fb *FrameBuffer) {
 }
 
 // FrameBufferTexture2D attaches a texture to a FrameBuffer
-func (c *Context) FrameBufferTexture2D(target, attachment, texTarget uint32, t *Texture, level int) {
+func (c *Context) FrameBufferTexture2D(target, attachment, texTarget int, t *Texture, level int) {
 	c.Call("framebufferTexture2D", target, attachment, texTarget, t.Value, level)
 }
 
 // FrameBufferRenderBuffer attaches a RenderBuffer object to a FrameBuffer object.
-func (c *Context) FrameBufferRenderBuffer(target, attachment uint32, rb *RenderBuffer) {
+func (c *Context) FrameBufferRenderBuffer(target, attachment int, rb *RenderBuffer) {
 	c.Call("framebufferRenderbuffer", target, attachment, c.RENDERBUFFER, rb.Value)
 }

--- a/gl_webgl.go
+++ b/gl_webgl.go
@@ -568,7 +568,7 @@ func (c *Context) InitialContextValues() {
 	c.RGB565 = webCtx.Get("RGB565").Int()
 	c.RGBA = webCtx.Get("RGBA").Int()
 	c.RGBA4 = webCtx.Get("RGBA4").Int()
-	c.RGBA8 = webCtx.Get("RGBA8").Int()
+	c.RGBA8 = webCtx.Get("RGBA4").Int() // use RGBA8 when available.
 	c.SAMPLER_2D = webCtx.Get("SAMPLER_2D").Int()
 	c.SAMPLER_CUBE = webCtx.Get("SAMPLER_CUBE").Int()
 	c.SAMPLES = webCtx.Get("SAMPLES").Int()

--- a/gl_webgl.go
+++ b/gl_webgl.go
@@ -1300,6 +1300,10 @@ func (c *Context) TexImage2D(target, level, internalFormat, format, kind int, da
 	}
 }
 
+func (c *Context) TexImage2DEmpty(target, level, internalFormat, format, kind, width, height int) {
+	c.Call("texImage2D", target, level, internalFormat, width, height, 0, format, kind, nil)
+}
+
 // Sets texture parameters for the current texture unit.
 func (c *Context) TexParameteri(target int, pname int, param int) {
 	c.Call("texParameteri", target, pname, param)


### PR DESCRIPTION
BindRenderbuffer + BindFramebuffer where implemented twice and there was no way to "unbind" a renderbuffer.