### PR TITLE
added line stipple support on other platforms

### DIFF
--- a/gl_empty.go
+++ b/gl_empty.go
@@ -136,6 +136,7 @@ type Context struct {
 	LINES                                        int
 	LINE_LOOP                                    int
 	LINE_STRIP                                   int
+	LINE_STIPPLE                                 int
 	LINE_WIDTH                                   int
 	LINK_STATUS                                  int
 	LOW_FLOAT                                    int
@@ -378,6 +379,8 @@ func (c *Context) GetProgramInfoLog(program *Program) string {
 }
 
 func (c *Context) AttachShader(program *Program, shader *Shader) {}
+
+func (c *Context) LineStipple(factor int32, pattern uint16) {}
 
 func (c *Context) LineWidth(width float32) {}
 

--- a/gl_mobile.go
+++ b/gl_mobile.go
@@ -140,6 +140,7 @@ type Context struct {
 	LINES                                        int
 	LINE_LOOP                                    int
 	LINE_STRIP                                   int
+	LINE_STIPPLE int
 	LINE_WIDTH                                   int
 	LINK_STATUS                                  int
 	LOW_FLOAT                                    int
@@ -433,6 +434,7 @@ func NewContext(DrawContext interface{}) *Context {
 		LINES:                                        gl.LINES,
 		LINE_LOOP:                                    gl.LINE_LOOP,
 		LINE_STRIP:                                   gl.LINE_STRIP,
+		LINE_STIPPLE: gl.line
 		LINE_WIDTH:                                   gl.LINE_WIDTH,
 		LINK_STATUS:                                  gl.LINK_STATUS,
 		LOW_FLOAT:                                    gl.LOW_FLOAT,
@@ -1361,4 +1363,12 @@ func (c *Context) FrameBufferTexture2D(target, attachment, texTarget int, t *Tex
 // FrameBufferRenderBuffer attaches a RenderBuffer object to a FrameBuffer object.
 func (c *Context) FrameBufferRenderBuffer(target, attachment int, rb *RenderBuffer) {
 	c.ctx.FramebufferRenderbuffer(gl.Enum(target), gl.Enum(attachment), gl.Enum(c.RENDERBUFFER), rb.Renderbuffer)
+}
+
+// LineStipple is not supported on mobile platforms. Emulation using small
+// rectangles is easiest method.
+// See: https://stackoverflow.com/questions/6017176/gllinestipple-deprecated-in-opengl-3-1
+// for implementation suggestions.
+func (c *Context) LineStipple(factor int32, pattern uint16) {
+	log.Error("[WARNING!!!] LineStipple is not supported on mobile platoforms!")
 }

--- a/gl_webgl.go
+++ b/gl_webgl.go
@@ -185,6 +185,7 @@ type Context struct {
 	LINES                                        int
 	LINE_LOOP                                    int
 	LINE_STRIP                                   int
+	LINE_STIPPLE                                 int
 	LINE_WIDTH                                   int
 	LINK_STATUS                                  int
 	LOW_FLOAT                                    int
@@ -1530,4 +1531,12 @@ func (c *Context) FrameBufferTexture2D(target, attachment, texTarget int, t *Tex
 // FrameBufferRenderBuffer attaches a RenderBuffer object to a FrameBuffer object.
 func (c *Context) FrameBufferRenderBuffer(target, attachment int, rb *RenderBuffer) {
 	c.Call("framebufferRenderbuffer", target, attachment, c.RENDERBUFFER, rb.Value)
+}
+
+// LineStipple is not supported on webgl platforms. Emulation using small
+// rectangles is easiest method.
+// See: https://stackoverflow.com/questions/6017176/gllinestipple-deprecated-in-opengl-3-1
+// for implementation suggestions.
+func (c *Context) LineStipple(factor int32, pattern uint16) {
+	log.Error("[WARNING!!!] LineStipple is not supported on mobile platoforms!")
 }


### PR DESCRIPTION
Turns out the other platforms do not support it, unfortunately.