### PR TITLE
LINE_STIPPLE is not available in OpenGL ES.

### DIFF
--- a/gl_mobile.go
+++ b/gl_mobile.go
@@ -1,5 +1,6 @@
-//+build android ios
-//+build !nogl
+//go:build (android || ios) && !nogl
+// +build android ios
+// +build !nogl
 
 package gl
 
@@ -140,7 +141,6 @@ type Context struct {
 	LINES                                        int
 	LINE_LOOP                                    int
 	LINE_STRIP                                   int
-	LINE_STIPPLE int
 	LINE_WIDTH                                   int
 	LINK_STATUS                                  int
 	LOW_FLOAT                                    int
@@ -434,7 +434,6 @@ func NewContext(DrawContext interface{}) *Context {
 		LINES:                                        gl.LINES,
 		LINE_LOOP:                                    gl.LINE_LOOP,
 		LINE_STRIP:                                   gl.LINE_STRIP,
-		LINE_STIPPLE: gl.line
 		LINE_WIDTH:                                   gl.LINE_WIDTH,
 		LINK_STATUS:                                  gl.LINK_STATUS,
 		LOW_FLOAT:                                    gl.LOW_FLOAT,


### PR DESCRIPTION
- Helps with compiling code for mobile.